### PR TITLE
Added a method to filter out "ghost" objects GCS started to create

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -564,10 +564,12 @@ class GCSFileSystem(AsyncFileSystem):
         filtered_items = []
 
         for item in items:
-            if item.get("kind", "") != "storage#object" \
-                and item.get("size", "0") != "0" \
-                and item.get("crc32c", "") != "AAAAAA==":
-                filtered_items.append(item)
+            if item.get("kind", "") == "storage#object" \
+                and item.get("size", "") == "0" \
+                and item.get("crc32c", "") == "AAAAAA==":
+                # This is a ghost item, skip it
+                continue
+            filtered_items.append(item)
 
         return filtered_items
 


### PR DESCRIPTION
We suddenly found that each _actual_ object and even directories in GCS now have these nameless 0-sized files accompanying them. This messes up the compliance with filesystem protocols, e.g. by returning extra items in the `ls` results.

The commit is constructed to add an extra filter for such objects for page items processing.