### PR TITLE
SCIENCE-462 reintroduce ghost entries fix

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -580,7 +580,19 @@ class GCSFileSystem(AsyncFileSystem):
                 return [await self._get_object(path)]
             else:
                 return []
-        out = pseudodirs + items
+        dirty_out = pseudodirs + items
+
+        out = []
+        for entry in dirty_out:
+            if (
+                entry["name"].rstrip("/") == path
+                and entry.get("kind", "") == "storage#object"
+                and (entry.get("size", "") == "0" or entry.get("size", "") == 0)
+                and entry.get("crc32c", "") == "AAAAAA=="
+            ):
+                # this is the "ghost" object of an empty folder, skip it
+                continue
+            out.append(entry)
 
         use_snapshot_listing = inventory_report_info and inventory_report_info.get(
             "use_snapshot_listing"


### PR DESCRIPTION
https://remerge.atlassian.net/browse/SCIENCE-462
"ghost" files fix was lost during the upstream update.

The core of the issue is, GCS generates internal files with some nanosecond timestamp names in order to (guessing here) support pseudo-folder creation/existence.
The files are handled correctly by GCS browser UI, but _not_ by `gsutil` or libraries, since for them they are just normal objects.

The fix is to check entries for some telltale signs of it being a "technical" file and filter them out - they are not to be manipulated by end users to begin with.